### PR TITLE
Check validate_file for Windows drive path

### DIFF
--- a/autoloader.php
+++ b/autoloader.php
@@ -62,8 +62,10 @@ spl_autoload_register( function ( $resource = '' ) {
 		$resource_path = sprintf( '%s/inc/%s/%s.php', untrailingslashit( $theme_root ), $directory, $file_name );
 	}
 
-	if ( file_exists( $resource_path ) && 0 === validate_file( $resource_path ) ) {
-		// We already making sure that file is exists and valid.
+	$validate_file = validate_file( $resource_path );
+	// Function validate_file returns 2 for Windows drive path, so we check that as well.
+	if ( file_exists( $resource_path ) && ( 0 === $validate_file || 2 === $validate_file ) ) {
+		// We are already making sure that file exists and it's valid.
 		require_once( $resource_path ); // phpcs:ignore
 	}
 

--- a/autoloader.php
+++ b/autoloader.php
@@ -64,7 +64,7 @@ spl_autoload_register( function ( $resource = '' ) {
 
 	$validate_file = validate_file( $resource_path );
 	// Function validate_file returns 2 for Windows drive path, so we check that as well.
-	if ( file_exists( $resource_path ) && ( 0 === $validate_file || 2 === $validate_file ) ) {
+	if ( ! empty( $resource_path ) && file_exists( $resource_path ) && ( 0 === $validate_file || 2 === $validate_file ) ) {
 		// We are already making sure that file exists and it's valid.
 		require_once( $resource_path ); // phpcs:ignore
 	}

--- a/inc/classes/class-google-auth.php
+++ b/inc/classes/class-google-auth.php
@@ -57,7 +57,9 @@ class Google_Auth {
 
 		$vendor_autoload = sprintf( '%s/vendor/autoload.php', WP_GOOGLE_LOGIN_PATH );
 
-		if ( ! empty( $vendor_autoload ) && file_exists( $vendor_autoload ) && 0 === validate_file( $vendor_autoload ) ) {
+		$validate_file = validate_file( $vendor_autoload );
+		// Function validate_file returns 2 for Windows drive path, so we check that as well.
+		if ( ! empty( $vendor_autoload ) && file_exists( $vendor_autoload ) && ( 0 === $validate_file || 2 === $validate_file ) ) {
 			require_once( $vendor_autoload ); // phpcs:ignore
 		}
 

--- a/inc/classes/class-helper.php
+++ b/inc/classes/class-helper.php
@@ -25,7 +25,9 @@ class Helper {
 	 */
 	public static function render_template( $template_path, $variables = [], $echo = true ) {
 
-		if ( empty( $template_path ) || ! file_exists( $template_path ) || 0 !== validate_file( $template_path ) ) {
+		$validate_file = validate_file( $template_path );
+		// Function validate_file returns 2 for Windows drive path, so we check that as well.
+		if ( empty( $template_path ) || ! file_exists( $template_path ) || ( 0 !== $validate_file && 2 !== $validate_file ) ) {
 			return '';
 		}
 

--- a/wp-google-login.php
+++ b/wp-google-login.php
@@ -21,7 +21,9 @@ define( 'WP_GOOGLE_LOGIN_VERSION', '0.1' );
 $vendor_autoload = sprintf( '%s/vendor/autoload.php', WP_GOOGLE_LOGIN_PATH );
 
 // Missing vendor autoload file or invalid file path.
-if ( empty( $vendor_autoload ) || ! file_exists( $vendor_autoload ) || 0 !== validate_file( $vendor_autoload ) ) {
+$validate_file = validate_file( $vendor_autoload );
+// Function validate_file returns 2 for Windows drive path, so we check that as well.
+if ( empty( $vendor_autoload ) || ! file_exists( $vendor_autoload ) || ( 0 !== $validate_file && 2 !== $validate_file ) ) {
 	return;
 }
 


### PR DESCRIPTION
Function `validate_file` return 2 for Windows drive path, so we're checking this as well.
Ref - https://developer.wordpress.org/reference/functions/validate_file/

Otherwise it'll cause fatal error on Windows platform.